### PR TITLE
feat: implement git-browse integration

### DIFF
--- a/fzf-git.sh
+++ b/fzf-git.sh
@@ -105,6 +105,13 @@ _fzf_git_stashes() {
   cut -d: -f1
 }
 
+_fzf_git_browse() {
+  _fzf_git_check || return
+  git ls-files --full |
+    _fzf_git_fzf --tac --prompt '🌐 Browse> ' --preview "git diff --color=always -- {-1} | sed 1,4d; $_fzf_git_cat {-1}" |
+    xargs -L1 git browse origin 
+}
+
 if [[ -n $BASH_VERSION ]]; then
   bind '"\er": redraw-current-line'
   bind '"\C-g\C-f": "$(_fzf_git_files)\e\C-e\er"'
@@ -113,6 +120,7 @@ if [[ -n $BASH_VERSION ]]; then
   bind '"\C-g\C-h": "$(_fzf_git_hashes)\e\C-e\er"'
   bind '"\C-g\C-r": "$(_fzf_git_remotes)\e\C-e\er"'
   bind '"\C-g\C-s": "$(_fzf_git_stashes)\e\C-e\er"'
+  bind '"\C-g\C-w": "$(_fzf_git_browse)\e\C-e\er"'
 elif [[ -n $ZSH_VERSION ]]; then
   _fzf_git_join() {
     local item

--- a/fzf-git.sh
+++ b/fzf-git.sh
@@ -107,9 +107,11 @@ _fzf_git_stashes() {
 
 _fzf_git_browse() {
   _fzf_git_check || return
+  branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null)"
+  remote=$(git config branch."${branch}".remote || echo "origin")
   git ls-files --full |
     _fzf_git_fzf --tac --prompt '🌐 Browse> ' --preview "git diff --color=always -- {-1} | sed 1,4d; $_fzf_git_cat {-1}" |
-    xargs -L1 git browse origin 
+    xargs -L1 git browse "${remote}" 
 }
 
 if [[ -n $BASH_VERSION ]]; then


### PR DESCRIPTION
`git-browse` is provided via [git-extras][].

This change introduces `<c-g><c-w>` (mnemonic: **g**it **w**eb browse) to open
git files in the browser.

See <https://github.com/tj/git-extras/blob/master/man/git-browse.md> for
`git-browse` details.

[git-extras]: https://github.com/tj/git-extras