### PR TITLE
Fix _fzf_git_files not showing anything in clean repo on macOS

### DIFF
--- a/fzf-git.sh
+++ b/fzf-git.sh
@@ -132,7 +132,7 @@ fi
 _fzf_git_files() {
   _fzf_git_check || return
   (git -c color.status=always status --short
-   git ls-files | (excludes="$(git status -s | grep '^[^?]' | cut -c4-)"; [ -n "${excludes}" ] && grep -vf <(echo "${excludes}") || cat) | sed 's/^/   /') |
+   git ls-files | grep -vxFf <(git status -s | grep '^[^?]' | cut -c4-; echo :) | sed 's/^/   /') |
   _fzf_git_fzf -m --ansi --nth 2..,.. \
     --prompt '📁 Files> ' \
     --header $'CTRL-O (open in browser) ╱ ALT-E (open in editor)\n\n' \

--- a/fzf-git.sh
+++ b/fzf-git.sh
@@ -132,7 +132,7 @@ fi
 _fzf_git_files() {
   _fzf_git_check || return
   (git -c color.status=always status --short
-   git ls-files | grep -vf <(git status -s | grep '^[^?]' | cut -c4-) | sed 's/^/   /') |
+   git ls-files | (excludes="$(git status -s | grep '^[^?]' | cut -c4-)"; [ -n "${excludes}" ] && grep -vf <(echo "${excludes}") || cat) | sed 's/^/   /') |
   _fzf_git_fzf -m --ansi --nth 2..,.. \
     --prompt '📁 Files> ' \
     --header $'CTRL-O (open in browser) ╱ ALT-E (open in editor)\n\n' \


### PR DESCRIPTION
On both Linux and macOS, `grep -f` will match nothing when provided with
an empty file. However, unlike on Linux, when combined with `-v`, grep
on macOS will not match everything when provided with an empty file
while the `-v` flag is active. This results in `_fzf_git_files` being
empty when in a clean repository.

This fixes this behaviour by bypassing the grep command if there is
nothing to exclude.