### PR TITLE
Fix key binding trigger delay

### DIFF
--- a/fzf-git.sh
+++ b/fzf-git.sh
@@ -228,8 +228,8 @@ if [[ -n "${BASH_VERSION:-}" ]]; then
     bind '"\er": redraw-current-line'
     local o
     for o in "$@"; do
-      bind '"\C-g\C-'${o:0:1}'": "$(_fzf_git_'$o')\e\C-e\er"'
-      bind '"\C-g'${o:0:1}'": "$(_fzf_git_'$o')\e\C-e\er"'
+      bind '"\C-g\C-'${o:0:1}'": "`_fzf_git_'$o'`\e\C-e\er"'
+      bind '"\C-g'${o:0:1}'": "`_fzf_git_'$o'`\e\C-e\er"'
     done
   }
 elif [[ -n "${ZSH_VERSION:-}" ]]; then


### PR DESCRIPTION
Only a problem with `set blink-matching-paren on` in .inputrc, in which case there was a delay before the key bindings triggered.

Similar to https://github.com/junegunn/fzf/issues/580.