### PR TITLE
fix: select the hash only and not those look alike in commit title

### DIFF
--- a/fzf-git.sh
+++ b/fzf-git.sh
@@ -180,7 +180,7 @@ _fzf_git_hashes() {
     --bind 'ctrl-d:execute:grep -o "[a-f0-9]\{7,\}" <<< {} | head -n 1 | xargs git diff > /dev/tty' \
     --color hl:underline,hl+:underline \
     --preview 'grep -o "[a-f0-9]\{7,\}" <<< {} | head -n 1 | xargs git show --color=always' "$@" |
-  grep -o "[a-f0-9]\{7,\}"
+  grep -o "[a-f0-9]\{7,\}" | head -n 1
 }
 
 _fzf_git_remotes() {


### PR DESCRIPTION
I'm using a repo whose titles of commit are `commit <hash>`, and `ctrl-g` `ctrl-h` inserts two hashes.

The repo is branch `release` of [coc.nvim](https://github.com/neoclide/coc.nvim/commits/release)