### PR TITLE
Fix hashes when awk does not support interval expressions

### DIFF
--- a/fzf-git.sh
+++ b/fzf-git.sh
@@ -180,7 +180,7 @@ _fzf_git_hashes() {
     --bind 'ctrl-d:execute:grep -o "[a-f0-9]\{7,\}" <<< {} | head -n 1 | xargs git diff > /dev/tty' \
     --color hl:underline,hl+:underline \
     --preview 'grep -o "[a-f0-9]\{7,\}" <<< {} | head -n 1 | xargs git show --color=always' "$@" |
-  awk 'match($0, /[a-f0-9]{7,}/) { print substr($0, RSTART, RLENGTH) }'
+  awk 'match($0, /[a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9]*/) { print substr($0, RSTART, RLENGTH) }'
 }
 
 _fzf_git_remotes() {


### PR DESCRIPTION
Improve compatibility with more awk implementations like mawk or nawk by changing interval expression (not supported in those variants) with repetition. Even gawk which does support interval expressions, required additional option to enable such support until version 4.0.

Fixes #17