### PR TITLE
Ensure 'open in browser' contains file path

### DIFF
--- a/fzf-git.sh
+++ b/fzf-git.sh
@@ -74,7 +74,7 @@ elif [[ $# -gt 1 ]]; then
       remote=$2
       path=/tree/$branch
       ;;
-    file) path=/blob/$branch/$2 ;;
+    file) path=/blob/$branch/$(git rev-parse --show-prefix)$2 ;;
     tag)  path=/releases/tag/$2 ;;
     *)    exit 1 ;;
   esac


### PR DESCRIPTION
When opening a file in a browser from a repository sub-folder (`CTRL-G` `CTRL-F` and `CTRL-O`) the browser shows GitHub's 404 page because the file path is not included.

This PR will prefix the file path relative to the root of the repo.

Fixes https://github.com/junegunn/fzf-git.sh/issues/19