### PR TITLE
fix: force --no-branch for git status in the files binding

### DIFF
--- a/fzf-git.sh
+++ b/fzf-git.sh
@@ -133,7 +133,7 @@ fi
 
 _fzf_git_files() {
   _fzf_git_check || return
-  (git -c color.status=always status --short
+  (git -c color.status=always status --short --no-branch
    git ls-files | grep -vxFf <(git status -s | grep '^[^?]' | cut -c4-; echo :) | sed 's/^/   /') |
   _fzf_git_fzf -m --ansi --nth 2..,.. \
     --border-label '📁 Files' \


### PR DESCRIPTION
I noticed my _fzf_git_files widget started to add the `## branch...branch` line after I updated my ~/.gitconfig with `branch = true` in the status section. Adding `--no-branch` to the git status command makes sure the result is the same whatever the git config is.

Before the change (extra line with the branch information):
![Screenshot 2023-06-05 at 3 51 25 PM](https://github.com/junegunn/fzf-git.sh/assets/11839374/ed208190-98c6-4b7a-9344-e013b9bf6116)
After the change (expected behavior):
![Screenshot 2023-06-05 at 3 52 20 PM](https://github.com/junegunn/fzf-git.sh/assets/11839374/20f835f0-04f6-4d4e-aeed-231161b2b870)
