### PR TITLE
_fzf_git_files lists all files in the repository

### DIFF
--- a/fzf-git.sh
+++ b/fzf-git.sh
@@ -136,13 +136,18 @@ fi
 
 _fzf_git_files() {
   _fzf_git_check || return
+  local root query
+  root=$(git rev-parse --show-toplevel)
+  [[ $root != "$PWD" ]] && query='!../ '
+
   (git -c color.status=always status --short --no-branch
-   git ls-files "$(git rev-parse --show-toplevel)" | grep -vxFf <(git status -s | grep '^[^?]' | cut -c4-; echo :) | sed 's/^/   /') |
+   git ls-files "$root" | grep -vxFf <(git status -s | grep '^[^?]' | cut -c4-; echo :) | sed 's/^/   /') |
   _fzf_git_fzf -m --ansi --nth 2..,.. \
     --border-label '📁 Files' \
     --header $'CTRL-O (open in browser) ╱ ALT-E (open in editor)\n\n' \
     --bind "ctrl-o:execute-silent:bash $__fzf_git file {-1}" \
     --bind "alt-e:execute:${EDITOR:-vim} {-1} > /dev/tty" \
+    --query "$query" \
     --preview "git diff --no-ext-diff --color=always -- {-1} | sed 1,4d; $_fzf_git_cat {-1}" "$@" |
   cut -c4- | sed 's/.* -> //'
 }

--- a/fzf-git.sh
+++ b/fzf-git.sh
@@ -137,7 +137,7 @@ fi
 _fzf_git_files() {
   _fzf_git_check || return
   (git -c color.status=always status --short --no-branch
-   git ls-files | grep -vxFf <(git status -s | grep '^[^?]' | cut -c4-; echo :) | sed 's/^/   /') |
+   git ls-files "$(git rev-parse --show-toplevel)" | grep -vxFf <(git status -s | grep '^[^?]' | cut -c4-; echo :) | sed 's/^/   /') |
   _fzf_git_fzf -m --ansi --nth 2..,.. \
     --border-label '📁 Files' \
     --header $'CTRL-O (open in browser) ╱ ALT-E (open in editor)\n\n' \


### PR DESCRIPTION
When calling `_fzf_git_files` in a subdirectory of the repository, it lists the files under the current directory. While this behavior seems reasonable, but there are cases where we also want a list of all files in the repository. 
to achieve this, I modified it to pass the repository's root directory to `git ls-files`,  which lists all files in the repository.

Given that this might result in breaking changes, it's alright if this can't be merged. However, since fzf is a tool for filtering lists, I think convenience outweighs troublesomeness when we have more options.