### PR TITLE
Make zsh keybindings work for all modes

### DIFF
--- a/fzf-git.sh
+++ b/fzf-git.sh
@@ -252,12 +252,14 @@ elif [[ -n "${ZSH_VERSION:-}" ]]; then
   }
 
   __fzf_git_init() {
-    local o
+    local m o
     for o in "$@"; do
       eval "fzf-git-$o-widget() { local result=\$(_fzf_git_$o | __fzf_git_join); zle reset-prompt; LBUFFER+=\$result }"
       eval "zle -N fzf-git-$o-widget"
-      eval "bindkey '^g^${o[1]}' fzf-git-$o-widget"
-      eval "bindkey '^g${o[1]}' fzf-git-$o-widget"
+      for m in emacs vicmd viins; do
+        eval "bindkey -M $m '^g^${o[1]}' fzf-git-$o-widget"
+        eval "bindkey -M $m '^g${o[1]}' fzf-git-$o-widget"
+      done
     done
   }
 fi


### PR DESCRIPTION
This PR ensures that when sourced, the plugin binds all `^G^*` actions irrespective of editing mode.

Thus all keybindings will be available for emacs users as well as vi mode users in both insert and command mode.

Resolves #34