### PR TITLE
fix: add missing binding for shell-expand-line

### DIFF
--- a/fzf-git.sh
+++ b/fzf-git.sh
@@ -269,6 +269,7 @@ _fzf_git_worktrees() {
 if [[ -n "${BASH_VERSION:-}" ]]; then
   __fzf_git_init() {
     bind '"\er": redraw-current-line'
+    bind '"\e\C-e": shell-expand-line'
     local o
     for o in "$@"; do
       bind '"\C-g\C-'${o:0:1}'": "`_fzf_git_'$o'`\e\C-e\er"'


### PR DESCRIPTION
Fixes issue #39 

shell-expand-line is unbound in bash vi mode. We have to bind it manually, unlike in emacs mode which is the default