### PR TITLE
Use CTRL-L for changing layout instead of CTRL-/

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Usage
 ### Inside fzf
 
 * <kbd>TAB</kbd> or <kbd>SHIFT-TAB</kbd> to select multiple objects
-* <kbd>CTRL-/</kbd> to change preview window layout
+* <kbd>CTRL-l</kbd> to change preview window layout
 * <kbd>CTRL-O</kbd> to open the object in the web browser (in GitHub URL scheme)
 
 Customization
@@ -69,7 +69,7 @@ _fzf_git_fzf() {
     --border-label-pos=2 \
     --color='header:italic:underline,label:blue' \
     --preview-window='right,50%,border-left' \
-    --bind='ctrl-/:change-preview-window(down,50%,border-top|hidden|)' "$@"
+    --bind='ctrl-l:change-preview-window(down,50%,border-top|hidden|)' "$@"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Usage
 ### Inside fzf
 
 * <kbd>TAB</kbd> or <kbd>SHIFT-TAB</kbd> to select multiple objects
-* <kbd>CTRL-l</kbd> to change preview window layout
+* <kbd>CTRL-L</kbd> to change preview window layout
 * <kbd>CTRL-O</kbd> to open the object in the web browser (in GitHub URL scheme)
 
 Customization

--- a/fzf-git.sh
+++ b/fzf-git.sh
@@ -148,7 +148,7 @@ _fzf_git_fzf() {
     --border-label-pos=2 \
     --color='header:italic:underline,label:blue' \
     --preview-window='right,50%,border-left' \
-    --bind='ctrl-/:change-preview-window(down,50%,border-top|hidden|)' "$@"
+    --bind='ctrl-l:change-preview-window(down,50%,border-top|hidden|)' "$@"
 }
 
 _fzf_git_check() {
@@ -189,7 +189,7 @@ _fzf_git_branches() {
     --preview-window down,border-top,40% \
     --color hl:underline,hl+:underline \
     --no-hscroll \
-    --bind 'ctrl-/:change-preview-window(down,70%|hidden|)' \
+    --bind 'ctrl-l:change-preview-window(down,70%|hidden|)' \
     --bind "ctrl-o:execute-silent:bash $__fzf_git branch {}" \
     --bind "alt-a:change-border-label(🌳 All branches)+reload:bash \"$__fzf_git\" all-branches" \
     --preview "git log --oneline --graph --date=short --color=$(__fzf_git_color .) --pretty='format:%C(auto)%cd %h%d %s' \$(sed s/^..// <<< {} | cut -d' ' -f1) --" "$@" |
@@ -260,7 +260,7 @@ _fzf_git_each_ref() {
     --preview-window down,border-top,40% \
     --color hl:underline,hl+:underline \
     --no-hscroll \
-    --bind 'ctrl-/:change-preview-window(down,70%|hidden|)' \
+    --bind 'ctrl-l:change-preview-window(down,70%|hidden|)' \
     --bind "ctrl-o:execute-silent:bash $__fzf_git {1} {2}" \
     --bind "alt-e:execute:${EDITOR:-vim} <(git show {2}) > /dev/tty" \
     --bind "alt-a:change-border-label(🍀 Every ref)+reload:bash \"$__fzf_git\" all-refs" \


### PR DESCRIPTION
L stands for layout 'change preview window **L**ayout'. Proposing this, since this is more intuitive, and Ctrl-/ might have some issues.

I couldn't find the reason for why the current binding didn't work for me. If someone had the issue as well, please let me know. It just typed `/` in the preview window.

I use tmux inside alacritty.