### PR TITLE
feat: force pager

### DIFF
--- a/fzf-git.sh
+++ b/fzf-git.sh
@@ -50,6 +50,20 @@ __fzf_git_cat() {
   fi
 }
 
+__fzf_pager() {
+  local core_pager
+  core_pager=$(git config --get core.pager)
+  if [[ -n $FZF_PAGER ]]; then
+    echo "$FZF_PAGER"
+  elif [[ -n $GIT_PAGER ]]; then
+    echo "$GIT_PAGER"
+  elif [[ -n $core_pager ]]; then
+    echo "$core_pager"
+  else
+    echo cat
+  fi
+}
+
 if [[ $# -eq 1 ]]; then
   branches() {
     git branch "$@" --sort=-committerdate --sort=-HEAD --format=$'%(HEAD) %(color:yellow)%(refname:short) %(color:green)(%(committerdate:relative))\t%(color:blue)%(subject)%(color:reset)' --color=$(__fzf_git_color) | column -ts$'\t'
@@ -175,7 +189,7 @@ _fzf_git_files() {
     --bind "ctrl-o:execute-silent:bash $__fzf_git file {-1}" \
     --bind "alt-e:execute:${EDITOR:-vim} {-1} > /dev/tty" \
     --query "$query" \
-    --preview "git diff --no-ext-diff --color=$(__fzf_git_color .) -- {-1} | sed 1,4d; $(__fzf_git_cat) {-1}" "$@" |
+    --preview "git diff --no-ext-diff --color=$(__fzf_git_color .) -- {-1} | $(__fzf_pager); $(__fzf_git_cat) {-1}" "$@" |
   cut -c4- | sed 's/.* -> //'
 }
 
@@ -203,7 +217,7 @@ _fzf_git_tags() {
     --border-label '📛 Tags' \
     --header $'CTRL-O (open in browser)\n\n' \
     --bind "ctrl-o:execute-silent:bash $__fzf_git tag {}" \
-    --preview "git show --color=$(__fzf_git_color .) {}" "$@"
+    --preview "git show --color=$(__fzf_git_color .) {} | $(__fzf_pager)" "$@"
 }
 
 _fzf_git_hashes() {
@@ -216,7 +230,7 @@ _fzf_git_hashes() {
     --bind "ctrl-d:execute:grep -o '[a-f0-9]\{7,\}' <<< {} | head -n 1 | xargs git diff --color=$(__fzf_git_color) > /dev/tty" \
     --bind "alt-a:change-border-label(🍇 All hashes)+reload:bash \"$__fzf_git\" all-hashes" \
     --color hl:underline,hl+:underline \
-    --preview "grep -o '[a-f0-9]\{7,\}' <<< {} | head -n 1 | xargs git show --color=$(__fzf_git_color .)" "$@" |
+    --preview "grep -o '[a-f0-9]\{7,\}' <<< {} | head -n 1 | xargs git show --color=$(__fzf_git_color .) | $(__fzf_pager)" "$@" |
   awk 'match($0, /[a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9]*/) { print substr($0, RSTART, RLENGTH) }'
 }
 
@@ -238,7 +252,7 @@ _fzf_git_stashes() {
     --border-label '🥡 Stashes' \
     --header $'CTRL-X (drop stash)\n\n' \
     --bind 'ctrl-x:reload(git stash drop -q {1}; git stash list)' \
-    -d: --preview "git show --color=$(__fzf_git_color .) {1}" "$@" |
+    -d: --preview "git show --color=$(__fzf_git_color .) {1} | $(__fzf_pager)" "$@" |
   cut -d: -f1
 }
 
@@ -246,7 +260,7 @@ _fzf_git_lreflogs() {
   _fzf_git_check || return
   git reflog --color=$(__fzf_git_color) --format="%C(blue)%gD %C(yellow)%h%C(auto)%d %gs" | _fzf_git_fzf --ansi \
     --border-label '📒 Reflogs' \
-    --preview "git show --color=$(__fzf_git_color .) {1}" "$@" |
+    --preview "git show --color=$(__fzf_git_color .) {1} | $(__fzf_pager)" "$@" |
   awk '{print $1}'
 }
 

--- a/fzf-git.sh
+++ b/fzf-git.sh
@@ -50,18 +50,10 @@ __fzf_git_cat() {
   fi
 }
 
-__fzf_pager() {
-  local core_pager
-  core_pager=$(git config --get core.pager)
-  if [[ -n $FZF_PAGER ]]; then
-    echo "$FZF_PAGER"
-  elif [[ -n $GIT_PAGER ]]; then
-    echo "$GIT_PAGER"
-  elif [[ -n $core_pager ]]; then
-    echo "$core_pager"
-  else
-    echo cat
-  fi
+__fzf_git_pager() {
+  local pager
+  pager="${FZF_GIT_PAGER:-${GIT_PAGER:-$(git config --get core.pager 2>/dev/null)}}"
+  echo "${pager:-cat}"
 }
 
 if [[ $# -eq 1 ]]; then
@@ -189,7 +181,7 @@ _fzf_git_files() {
     --bind "ctrl-o:execute-silent:bash $__fzf_git file {-1}" \
     --bind "alt-e:execute:${EDITOR:-vim} {-1} > /dev/tty" \
     --query "$query" \
-    --preview "git diff --no-ext-diff --color=$(__fzf_git_color .) -- {-1} | $(__fzf_pager); $(__fzf_git_cat) {-1}" "$@" |
+    --preview "git diff --no-ext-diff --color=$(__fzf_git_color .) -- {-1} | $(__fzf_git_pager); $(__fzf_git_cat) {-1}" "$@" |
   cut -c4- | sed 's/.* -> //'
 }
 
@@ -217,7 +209,7 @@ _fzf_git_tags() {
     --border-label '📛 Tags' \
     --header $'CTRL-O (open in browser)\n\n' \
     --bind "ctrl-o:execute-silent:bash $__fzf_git tag {}" \
-    --preview "git show --color=$(__fzf_git_color .) {} | $(__fzf_pager)" "$@"
+    --preview "git show --color=$(__fzf_git_color .) {} | $(__fzf_git_pager)" "$@"
 }
 
 _fzf_git_hashes() {
@@ -230,7 +222,7 @@ _fzf_git_hashes() {
     --bind "ctrl-d:execute:grep -o '[a-f0-9]\{7,\}' <<< {} | head -n 1 | xargs git diff --color=$(__fzf_git_color) > /dev/tty" \
     --bind "alt-a:change-border-label(🍇 All hashes)+reload:bash \"$__fzf_git\" all-hashes" \
     --color hl:underline,hl+:underline \
-    --preview "grep -o '[a-f0-9]\{7,\}' <<< {} | head -n 1 | xargs git show --color=$(__fzf_git_color .) | $(__fzf_pager)" "$@" |
+    --preview "grep -o '[a-f0-9]\{7,\}' <<< {} | head -n 1 | xargs git show --color=$(__fzf_git_color .) | $(__fzf_git_pager)" "$@" |
   awk 'match($0, /[a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9]*/) { print substr($0, RSTART, RLENGTH) }'
 }
 
@@ -252,7 +244,7 @@ _fzf_git_stashes() {
     --border-label '🥡 Stashes' \
     --header $'CTRL-X (drop stash)\n\n' \
     --bind 'ctrl-x:reload(git stash drop -q {1}; git stash list)' \
-    -d: --preview "git show --color=$(__fzf_git_color .) {1} | $(__fzf_pager)" "$@" |
+    -d: --preview "git show --color=$(__fzf_git_color .) {1} | $(__fzf_git_pager)" "$@" |
   cut -d: -f1
 }
 
@@ -260,7 +252,7 @@ _fzf_git_lreflogs() {
   _fzf_git_check || return
   git reflog --color=$(__fzf_git_color) --format="%C(blue)%gD %C(yellow)%h%C(auto)%d %gs" | _fzf_git_fzf --ansi \
     --border-label '📒 Reflogs' \
-    --preview "git show --color=$(__fzf_git_color .) {1} | $(__fzf_pager)" "$@" |
+    --preview "git show --color=$(__fzf_git_color .) {1} | $(__fzf_git_pager)" "$@" |
   awk '{print $1}'
 }
 


### PR DESCRIPTION
- Close #47

### Description

When you configure `core.pager` in your global gitconfig file, it allows you to run git commands like `git show`, and the assigned pager will be used automatically.

```sh
brew install diff-so-fancy
git config --global core.pager "diff-so-fancy"
git show @
```

The **problem** is that `git` checks if `stdout` is a `tty`[^1] and only then uses the `pager`; otherwise, it doesn't. Commands run in the `fzf` preview window fail this `tty`[^2] test, and thus no pager will be used.


Below the relvant source code snippet from `git/git` repo with the `isatty(1)` check.

```c
// git/pager.c
const char *git_pager(int stdout_is_tty)
{
	const char *pager;

	if (!stdout_is_tty)
		return NULL;
	…
}

void setup_pager(void)
{
	const char *pager = git_pager(isatty(1));

	if (!pager)
		return;
	…
}
```

Unlike the `--color=always` flag, there is no environment variable or flag that can be passed to force the use of a pager.

### Solution


The function `__fzf_pager` is designed to check whether `core.pager`, `GIT_PAGER`, or `FZF_PAGER` is set, thereby enabling the user to utilize their preferred highlighter, such as `delta`[^3] or `diff-so-fancy`[^4].
```sh
export FZF_PAGER="delta"
export FZF_PAGER="diff-so-fancy"
```
The function and explanation for this PR are inspired by a discussion on the git issue tracker[^5].

<img src="https://raw.githubusercontent.com/LangLangbart/ImagePool/c3cc118e3a6d740b81737160c48e15e2da46912e/storage/2024-06-30_23-51-48_Screenshot2024-06-30at23.32.17.png" width="600">

<details>

---

<summary><b>Personal gitconfig</b></summary>

The file is provided only if there is a desire to reproduce the layout seen in the image above.
```cfg
[filter "lfs"]
	clean = git-lfs clean -- %f
	smudge = git-lfs smudge -- %f
	process = git-lfs filter-process
	required = true
[user]
	name = LangLangbart
	email = ???
[color]
	ui = auto
[core]
	autocrlf = input
	editor = codium --wait
	excludesFile = ~/.gitignore_global
	pager = delta
	# https://blog.cuviper.com/2013/11/10/how-short-can-git-abbreviate/
	abbrev = 12
[advice]
	detachedHead = false
[interactive]
	diffFilter = delta --color-only
[delta]
	# author: https://github.com/Kr1ss-XD
	commit-style = 232 bold italic 130
	dark = true
	file-added-label = [+]
	file-copied-label = [C]
	file-modified-label = [M]
	file-removed-label = [-]
	file-renamed-label = [R]
	file-style = 255 bold 27
	hunk-header-decoration-style = none
	hunk-header-style = syntax bold italic 237
	line-numbers = true
	line-numbers-left-format = "{nm:>1}│"
	line-numbers-left-style = red
	line-numbers-minus-style = red italic
	line-numbers-plus-style = green italic
	line-numbers-right-format = "{np:>1}│"
	line-numbers-right-style = green
	line-numbers-zero-style = "#545474" italic
	minus-emph-style = syntax bold "#780000"
	minus-style = syntax "#400000"
	plus-emph-style = syntax bold "#007800"
	plus-style = syntax "#004000"
	whitespace-error-style = "#280050" reverse
	zero-style = syntax
	blame-format = "{author:<18} ({commit:>7}) ┊{timestamp:^16}┊ "
	blame-palette = "#101010 #200020 #002800 #000028 #202000 #280000 #002020 #002800 #202020"
[diff]
	colorMoved = default
	renameLimit = 992
[pull]
	rebase = merges
[log]
	date = format:%d/%b/%y
	decorate = auto
	abbrevCommit = true
[init]
	defaultBranch = main
	# modify the default hooks in newly cloned or initialized repositories
	templatedir = ~/.dotfiles/git
[push]
	default = simple
[grep]
	extendedRegexp = true
[url "git@github.com:"]
	insteadOf = https://github.com/
[branch]
	sort = -committerdate
```

---

</details>


### Remaining issues:

- Is it desirable to have such a new function at all, or should the solution be to alter `fzf` preview window so as to trick `git` into thinking it is a `tty`?
- Should the `FZF_PAGER` environment variable be described in the `README`?
- For the `_fzf_git_files` function, the `sed` part was removed as it would alter the diff. A solution would be to include an `if` check to determine whether the `__fzf_pager` function returns something other than `cat`.



[^1]: [git/pager.c · git/git](https://github.com/git/git/blob/790a17fb19d6eadd16c52e5d284a5c6921744766/pager.c)
[^2]: [Issue #1118 · junegunn/fzf](https://github.com/junegunn/fzf/issues/1118#issuecomment-341415350)
[^3]: [dandavison/delta](https://github.com/dandavison/delta)
[^4]: [so-fancy/diff-so-fancy](https://github.com/so-fancy/diff-so-fancy)
[^5]: [Force usage of pager for diff, show, etc when piping to non-TTY · lore.kernel.org](https://lore.kernel.org/git/20230816025715.GB2248431@coredump.intra.peff.net/T/#u)
