### PR TITLE
refactor: improve git ref formatting and filtering

### DIFF
--- a/fzf-git.sh
+++ b/fzf-git.sh
@@ -61,7 +61,7 @@ if [[ $# -eq 1 ]]; then
     git branch "$@" --sort=-committerdate --sort=-HEAD --format=$'%(HEAD) %(color:yellow)%(refname:short) %(color:green)(%(committerdate:relative))\t%(color:blue)%(subject)%(color:reset)' --color=$(__fzf_git_color) | column -ts$'\t'
   }
   refs() {
-    git for-each-ref "$@" --sort=-creatordate --sort=-HEAD --color=$(__fzf_git_color) --format=$'%(if:equals=refs/remotes)%(refname:rstrip=-2)%(then)%(color:magenta)remote-branch%(else)%(if:equals=refs/heads)%(refname:rstrip=-2)%(then)%(color:brightgreen)branch%(else)%(if:equals=refs/tags)%(refname:rstrip=-2)%(then)%(color:brightblue)tag%(else)%(if:equals=refs/stash)%(refname:rstrip=-2)%(then)%(color:brightred)stash%(else)%(color:white)%(refname:rstrip=-2)%(end)%(end)%(end)%(end)\t%(color:yellow)%(refname:short) %(color:green)(%(creatordate:relative))\t%(color:blue)%(subject)%(color:reset)' | column -ts$'\t'
+    git for-each-ref "$@" --sort=-creatordate --sort=-HEAD --color=$(__fzf_git_color) --format=$'%(if:equals=refs/remotes)%(refname:rstrip=-2)%(then)%(color:magenta)remote-branch%(else)%(if:equals=refs/heads)%(refname:rstrip=-2)%(then)%(color:brightgreen)branch%(else)%(if:equals=refs/tags)%(refname:rstrip=-2)%(then)%(color:brightcyan)tag%(else)%(if:equals=refs/stash)%(refname:rstrip=-2)%(then)%(color:brightred)stash%(else)%(color:white)%(refname:rstrip=-2)%(end)%(end)%(end)%(end)\t%(color:yellow)%(refname:short) %(color:green)(%(creatordate:relative))\t%(color:blue)%(subject)%(color:reset)' | column -ts$'\t'
   }
   hashes() {
     git log --date=short --format="%C(green)%C(bold)%cd %C(auto)%h%d %s (%an)" --graph --color=$(__fzf_git_color) "$@"

--- a/fzf-git.sh
+++ b/fzf-git.sh
@@ -61,10 +61,7 @@ if [[ $# -eq 1 ]]; then
     git branch "$@" --sort=-committerdate --sort=-HEAD --format=$'%(HEAD) %(color:yellow)%(refname:short) %(color:green)(%(committerdate:relative))\t%(color:blue)%(subject)%(color:reset)' --color=$(__fzf_git_color) | column -ts$'\t'
   }
   refs() {
-    git for-each-ref --sort=-creatordate --sort=-HEAD --color=$(__fzf_git_color) --format=$'%(refname) %(color:green)(%(creatordate:relative))\t%(color:blue)%(subject)%(color:reset)' |
-      eval "$1" |
-      sed 's#^refs/remotes/#\x1b[95mremote-branch\t\x1b[33m#; s#^refs/heads/#\x1b[92mbranch\t\x1b[33m#; s#^refs/tags/#\x1b[96mtag\t\x1b[33m#; s#refs/stash#\x1b[91mstash\t\x1b[33mrefs/stash#' |
-      column -ts$'\t'
+    git for-each-ref "$@" --sort=-creatordate --sort=-HEAD --color=$(__fzf_git_color) --format=$'%(if:equals=refs/remotes)%(refname:rstrip=-2)%(then)%(color:magenta)remote-branch%(else)%(if:equals=refs/heads)%(refname:rstrip=-2)%(then)%(color:brightgreen)branch%(else)%(if:equals=refs/tags)%(refname:rstrip=-2)%(then)%(color:brightblue)tag%(else)%(if:equals=refs/stash)%(refname:rstrip=-2)%(then)%(color:brightred)stash%(else)%(color:white)%(refname:rstrip=-2)%(end)%(end)%(end)%(end)\t%(color:yellow)%(refname:short) %(color:green)(%(creatordate:relative))\t%(color:blue)%(subject)%(color:reset)' | column -ts$'\t'
   }
   hashes() {
     git log --date=short --format="%C(green)%C(bold)%cd %C(auto)%h%d %s (%an)" --graph --color=$(__fzf_git_color) "$@"
@@ -88,11 +85,11 @@ if [[ $# -eq 1 ]]; then
       ;;
     refs)
       echo $'CTRL-O (open in browser) ╱ ALT-E (examine in editor) ╱ ALT-A (show all refs)\n'
-      refs 'grep -v ^refs/remotes'
+      refs --exclude='refs/remotes'
       ;;
     all-refs)
       echo $'CTRL-O (open in browser) ╱ ALT-E (examine in editor)\n'
-      refs 'cat'
+      refs
       ;;
     nobeep) ;;
     *) exit 1 ;;


### PR DESCRIPTION
#### description


The issue with the current `refs` is that the `sed` command is missing the `$'` in front of the term so that `\t` (tabs) can be expanded, as my `sed` version is unable to do so.

<img src="https://raw.githubusercontent.com/LangLangbart/ImagePool/410b7e182baa9f056d6ad5b36f18aca89e40869e/storage/2024-07-06_06-25-08_Screenshot2024-07-06at05.48.09.png" width="600">

Another issue is that assigning `FZF_GIT_COLOR=never` has no effect because the colorization takes place in the `sed` part.

Additionally, other `refs`, for example when doing a `git bisect`, weren't colorized and would disrupt the columnization.

<img src="https://raw.githubusercontent.com/LangLangbart/ImagePool/8059f9e1eb72ce36cbbaf84d0fa39c84a4d2a36b/storage/2024-07-06_06-25-43_Screenshot2024-07-06at05.48.31.png" width="600">

### intended solution
- Remove `sed` and use the built-in `%(if) … %(then) … %(else) … %(end)` syntax[^1][^2] to colorize[^3] the possible values of `%(refname)`:
    - `refs/remotes` (magenta)
    - `refs/heads` (brightgreen)
    - `refs/tags` (brightblue)
    - `refs/stash` (brightred)
    - others (white)

Unfortunately, there is no `%(else if)` construct available, so one has to construct nested `%(if)` terms.

<img src="https://raw.githubusercontent.com/LangLangbart/ImagePool/8eedcba992c12445bb8f8942051054397aff3c17/storage/2024-07-06_06-26-02_Screenshot2024-07-06at05.50.43.png" width="600">

### open questions
Should other `refs` like `refs/bisect` even be listed at all ?

Are the colors okay ?

Would you like me to add a toogle to the <kbd>⌥ Option</kbd> + <kbd>A</kbd> keybind in an extra PR or is the feature still too young[^4] ?
```diff
--- a/fzf-git.sh
+++ b/fzf-git.sh
@@ -267,5 +267,7 @@ _fzf_git_each_ref() {
     --bind "ctrl-o:execute-silent:bash $__fzf_git {1} {2}" \
     --bind "alt-e:execute:${EDITOR:-vim} <(git show {2}) > /dev/tty" \
-    --bind "alt-a:change-border-label(🍀 Every ref)+reload:bash \"$__fzf_git\" all-refs" \
+    --bind "alt-a:transform:[[ ! \$FZF_BORDER_LABEL =~ Each ]] \
+      && echo 'change-border-label(☘️  Each ref)+reload:bash \"$__fzf_git\" refs' \
+      || echo 'change-border-label(🍀 Every ref)+reload:bash \"$__fzf_git\" all-refs'" \
     --preview "git log --oneline --graph --date=short --color=$(__fzf_git_color .) --pretty='format:%C(auto)%cd %h%d %s' {2} --" "$@" |
   awk '{print $2}'
```



[^1]: [[PATCH 00/15] port branch.c to use ref-filter's printing options](https://lore.kernel.org/all/1457265902-7949-2-git-send-email-Karthik.188@gmail.com/T/#u)
[^2]: [Git - git-for-each-ref Documentation - %(if)](https://git-scm.com/docs/git-for-each-ref#Documentation/git-for-each-ref.txt-if)
[^3]: [Git - git-config Documentation - color](https://git-scm.com/docs/git-config#Documentation/git-config.txt-color)
[^4]: [Add environment variables: FZF_{BORDER,PREVIEW}_LABEL (#3693) · junegunn/fzf@f625c5a · GitHub](https://github.com/junegunn/fzf/commit/f625c5aabe0e4cdbfc4a1d5d526a011d3c68c697)
