### PR TITLE
vim-open (Enter), checkout/switch to commit/branch (C-C), toogle preview (C-P)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,100 +1,25 @@
 fzf-git.sh
 ==========
 
-bash and zsh key bindings for Git objects, powered by [fzf][fzf].
+**FORK** of  [junegunn/fzf-git.sh](https://github.com/junegunn/fzf-git.sh)
 
-<img width="1680" alt="image" src="https://user-images.githubusercontent.com/700826/185568470-20d70937-eea4-4274-aec5-14dfe7ee2de6.png">
-
-Each binding will allow you to browse through Git objects of a certain type,
-and select the objects you want to paste to your command-line.
-
-[fzf]: https://github.com/junegunn/fzf
 
 Installation
 ------------
 
-1. Install the latest version of [fzf][fzf]
-    * (Optional) Install [bat](https://github.com/sharkdp/bat) for
-      syntax-highlighted file previews
-1. Source [fzf-git.sh](https://raw.githubusercontent.com/junegunn/fzf-git.sh/main/fzf-git.sh) file from your .bashrc or .zshrc
-
-Usage
------
-
-### List of bindings
-
-* <kbd>CTRL-G</kbd><kbd>CTRL-F</kbd> for **F**iles
-* <kbd>CTRL-G</kbd><kbd>CTRL-B</kbd> for **B**ranches
-* <kbd>CTRL-G</kbd><kbd>CTRL-T</kbd> for **T**ags
-* <kbd>CTRL-G</kbd><kbd>CTRL-R</kbd> for **R**emotes
-* <kbd>CTRL-G</kbd><kbd>CTRL-H</kbd> for commit **H**ashes
-* <kbd>CTRL-G</kbd><kbd>CTRL-S</kbd> for **S**tashes
-* <kbd>CTRL-G</kbd><kbd>CTRL-L</kbd> for ref**l**ogs
-* <kbd>CTRL-G</kbd><kbd>CTRL-W</kbd> for **W**orktrees
-* <kbd>CTRL-G</kbd><kbd>CTRL-E</kbd> for **E**ach ref (`git for-each-ref`)
-
-> [!WARNING]
-> You may have issues with these bindings in the following cases:
->
-> * <kbd>CTRL-G</kbd><kbd>CTRL-B</kbd> will not work if
->   <kbd>CTRL-B</kbd> is used as the tmux prefix
-> * <kbd>CTRL-G</kbd><kbd>CTRL-S</kbd> will not work if flow control is enabled,
->   <kbd>CTRL-S</kbd> will freeze the terminal instead
->     * (`stty -ixon` will disable it)
->
-> To workaround the problems, you can use
-> <kbd>CTRL-G</kbd><kbd>*{key}*</kbd> instead of
-> <kbd>CTRL-G</kbd><kbd>CTRL-*{KEY}*</kbd>.
->
-
-> [!WARNING]
-> If zsh's `KEYTIMEOUT` is too small (e.g. 1), you may not be able
-> to hit two keys in time.
-
-### Inside fzf
-
-* <kbd>TAB</kbd> or <kbd>SHIFT-TAB</kbd> to select multiple objects
-* <kbd>CTRL-/</kbd> to change preview window layout
-* <kbd>CTRL-O</kbd> to open the object in the web browser (in GitHub URL scheme)
-
-Customization
--------------
-
 ```sh
-# Redefine this function to change the options
-_fzf_git_fzf() {
-  fzf --height=50% --tmux 90%,70% \
-    --layout=reverse --multi --min-height=20 --border \
-    --border-label-pos=2 \
-    --color='header:italic:underline,label:blue' \
-    --preview-window='right,50%,border-left' \
-    --bind='ctrl-/:change-preview-window(down,50%,border-top|hidden|)' "$@"
-}
+FZF_GIT_SCRIPT=~/fzf-git.sh/fzf-git.sh
+[ ! -f "$FZF_GIT_SCRIPT" ] && \
+  cd $HOME && git clone https://github.com/juanMarinero/fzf-git.sh
+source "$FZF_GIT_SCRIPT"
 ```
 
-Defining shortcut commands
---------------------------
+Purpose
+------------
 
-Each binding is backed by `_fzf_git_*` function so you can do something like
-this in your shell configuration file.
+Integrate **Vim** navigation alike [vimcast-34](http://vimcasts.org/episodes/fugitive-vim-browsing-the-git-object-database/) and  [vimcast-35](http://vimcasts.org/episodes/fugitive-vim-exploring-the-history-of-a-git-repository/).
 
-```sh
-gco() {
-  _fzf_git_each_ref --no-multi | xargs git checkout
-}
+License
+------------
 
-gswt() {
-  cd "$(_fzf_git_worktrees --no-multi)"
-}
-```
-
-Environment Variables
----------------------
-
-| Variable                | Description                                              | Default                                         |
-| ----------------------- | -------------------------------------------------------- | ----------------------------------------------- |
-| `BAT_STYLE`             | Specifies the style for displaying files using `bat`     | `full`                                          |
-| `FZF_GIT_CAT`           | Defines the preview command used for displaying the file | `bat --style=$BAT_STYLE --color=$FZF_GIT_COLOR` |
-| `FZF_GIT_COLOR`         | Set to `never` to suppress colors in the list            | `always`                                        |
-| `FZF_GIT_PAGER`         | Specifies the pager command for the preview window       | `$(git config --get core.pager)`                |
-| `FZF_GIT_PREVIEW_COLOR` | Set to `never` to suppress colors in the preview window  | `always`                                        |
+MIT License (MIT)

--- a/fzf-git.sh
+++ b/fzf-git.sh
@@ -199,6 +199,7 @@ _fzf_git_branches() {
     --bind 'ctrl-/:change-preview-window(down,70%|hidden|)' \
     --bind "ctrl-o:execute-silent:bash \"$__fzf_git\" --list branch {}" \
     --bind "alt-a:change-border-label(🌳 All branches)+reload:bash \"$__fzf_git\" --list all-branches" \
+    --bind "enter:execute:sed 's/^..//' <<< {} | cut -d' ' -f1 | xargs -I % sh -c 'vim -c \":Gedit %\" < /dev/tty'" \
     --preview "git log --oneline --graph --date=short --color=$(__fzf_git_color .) --pretty='format:%C(auto)%cd %h%d %s' \$(sed s/^..// <<< {} | cut -d' ' -f1) --" "$@" |
   sed 's/^..//' | cut -d' ' -f1
 }

--- a/fzf-git.sh
+++ b/fzf-git.sh
@@ -215,11 +215,14 @@ _fzf_git_hashes() {
   _fzf_git_check || return
   bash "$__fzf_git" --list hashes |
   _fzf_git_fzf --ansi --no-sort --bind 'ctrl-s:toggle-sort' \
+    --preview 'f() { set -- $(echo -- "$@" | grep -o "[a-f0-9]\{7\}"); [ $# -eq 0 ] || git show --color=always $1 ; }; f {}' \
+    --bind=ctrl-p:toggle-preview \
     --border-label '🍡 Hashes' \
     --header-lines 3 \
     --bind "ctrl-o:execute-silent:bash \"$__fzf_git\" --list commit {}" \
     --bind "ctrl-d:execute:grep -o '[a-f0-9]\{7,\}' <<< {} | head -n 1 | xargs git diff --color=$(__fzf_git_color) > /dev/tty" \
     --bind "alt-a:change-border-label(🍇 All hashes)+reload:bash \"$__fzf_git\" --list all-hashes" \
+    --bind "enter:execute:grep -o '[a-f0-9]\{7\}' <<< {} | head -n 1 | xargs -I % sh -c 'vim -c \":Gedit %\" < /dev/tty'" \
     --color hl:underline,hl+:underline \
     --preview "grep -o '[a-f0-9]\{7,\}' <<< {} | head -n 1 | xargs git show --color=$(__fzf_git_color .) | $(__fzf_git_pager)" "$@" |
   awk 'match($0, /[a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9]*/) { print substr($0, RSTART, RLENGTH) }'


### PR DESCRIPTION
- README.md not to be pulled (commit [a25fd95](https://github.com/junegunn/fzf-git.sh/commit/a25fd95f36a81dd4044621ed18c6a47bfbab1939))

- Vim-open , i.e. :Gedit, pressing Enter works fine
- toogle preview (Ctrl-P) in commits (Ctrl+G Ctrl+H) works fine

- checkout/switch to commit/branch (Ctrl-C) is very workarounded concerning shortcuts. Because terminal prompt does not update (showing new HEAD commit hash or branch) as soon as fzf-git.sh exists, i.e. when pressed Ctrl-C (C stands for checkout)
...thus added code to `Define a new widget that chains the two widgets together` in commit [46d8392](https://github.com/junegunn/fzf-git.sh/commit/46d839295fea57c4f072b87782bceb8467f9ab64#diff-0734083c99301d10f2914f0db6c255a56e8947417b2ec966d2f4441083a8b003R360).

I will try to make cleaner code and commit msgs in future. Always learning! Thanks for your repo and time Junegunn!