### PR TITLE
docs: update git requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Installation
 1. Install the latest version of [fzf][fzf]
     * (Optional) Install [bat](https://github.com/sharkdp/bat) for
       syntax-highlighted file previews
+    * Git v2.42.0 is required for the `git for-each-ref` binding
 1. Source [fzf-git.sh](https://raw.githubusercontent.com/junegunn/fzf-git.sh/main/fzf-git.sh) file from your .bashrc or .zshrc
 
 Usage

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Installation
 1. Install the latest version of [fzf][fzf]
     * (Optional) Install [bat](https://github.com/sharkdp/bat) for
       syntax-highlighted file previews
-    * Git v2.42.0 is required for the `git for-each-ref` binding
+    * Git v2.42.0 or later is required for the `git for-each-ref` binding
 1. Source [fzf-git.sh](https://raw.githubusercontent.com/junegunn/fzf-git.sh/main/fzf-git.sh) file from your .bashrc or .zshrc
 
 Usage


### PR DESCRIPTION
ref: #63

---

The `--exclude=` flag for `git for-each-ref` was added to Git in commit `8255dd8`[^1] and released
with `v2.42.0`[^2] (August 2023).

With PR #53 (July 2024), I used the flag as documented in the man page, but I did not verify when
this particular flag was added, leading to the issue described in #63.

@mheuvel-dev

Add a small note as suggested.

Ref: Versions for git - https://repology.org/project/git/versions

[^1]: https://git.kernel.org/pub/scm/git/git.git/commit/?id=8255dd8
[^2]: https://git.kernel.org/pub/scm/git/git.git/log/Documentation/RelNotes/2.42.0.txt
