### PR TITLE
Update all-branches sed to remove up until first slash

### DIFF
--- a/fzf-git.sh
+++ b/fzf-git.sh
@@ -202,7 +202,7 @@ _fzf_git_branches() {
     --bind "ctrl-o:execute-silent:bash \"$__fzf_git\" --list branch {}" \
     --bind "alt-a:change-border-label(🌳 All branches)+reload:bash \"$__fzf_git\" --list all-branches" \
     --bind "alt-h:become:LIST_OPTS=\$(cut -c3- <<< {} | cut -d' ' -f1) bash \"$__fzf_git\" --run hashes" \
-    --bind "alt-enter:become:printf '%s\n' {+} | cut -c3- | sed 's@.*/@@'" \
+    --bind "alt-enter:become:printf '%s\n' {+} | cut -c3- | sed 's@[^/]*/@@'" \
     --preview "git log --oneline --graph --date=short --color=$(__fzf_git_color .) --pretty='format:%C(auto)%cd %h%d %s' \$(cut -c3- <<< {} | cut -d' ' -f1) --" "$@" |
   sed 's/^\* //' | awk '{print $1}' # Slightly modified to work with hashes as well
 }


### PR DESCRIPTION
@junegunn added [`ec21e8e`](https://github.com/junegunn/fzf-git.sh/commit/ec21e8e5d1d680905029378fd9a7f8bbb4f57b40) which allowed for omitting the remote name from a branch when selecting a remote branch.

However it also omitted everything in the branch name up until the _last_ slash. For example, `origin/feature/ticker-number-0000` became `ticker-number-0000` instead of `feature/ticker-number-0000`.

This pull request updates the `sed` substitution to only omit up until the _first_ slash instead of the last.
