### PR TITLE
Fix short hash extraction to ignore commit title

### DIFF
--- a/fzf-git.sh
+++ b/fzf-git.sh
@@ -110,7 +110,7 @@ if [[ $1 = --list ]]; then
     # Only supports GitHub for now
     case "$1" in
       commit)
-        hash=$(grep -o "[a-f0-9]\{7,\}" <<< "$2")
+        hash=$(grep -o "[a-f0-9]\{7,\}" <<< "$2" | head -n 1)
         path=/commit/$hash
         ;;
       branch|remote-branch)


### PR DESCRIPTION
Renovate bot sometimes creates commits whose titles include another commit hash, potentially from a different repository.
For example: https://github.com/kachick/dotfiles/commit/8d6ae7b

In this case, running `bash "$__fzf_git" --list hashes` parses the entire commit title as a single line and extracts all matching hash-like strings via grep:

```console
> entry='* 2025-04-30 8d6ae7b chore(deps): update ghcr.io/kachick/ubuntu-24.04-nix-systemd:latest docker digest to bbbb2fa (#1159) (renovate[bot])'
> grep -o "[a-f0-9]\{7,\}" <<< "$entry"
8d6ae7b
bbbb2fa
```

As a result, the `Ctrl+O` binding may try to open an invalid URL like: https://github.com/kachick/dotfiles/commit/8d6ae7bbbbb2fa

To fix this, I suggest using `head` to only extract the first match.
This approach keeps consistency, as `head -n 1` is already used elsewhere in `fzf-git.sh`.