### PR TITLE
Support opening GitHub URLs via WSL

### DIFF
--- a/fzf-git.sh
+++ b/fzf-git.sh
@@ -140,8 +140,16 @@ if [[ $1 = --list ]]; then
     fi
 
     case "$(uname -s)" in
-      Darwin) open "$url$path"     ;;
-      *)      xdg-open "$url$path" ;;
+      Darwin)
+        open "$url$path"
+        ;;
+      *)
+        if [[ -n "${WSL_DISTRO_NAME:-}" ]]; then
+          explorer.exe "$url$path"
+        else
+          xdg-open "$url$path"
+        fi
+        ;;
     esac
     exit 0
   fi

--- a/fzf-git.sh
+++ b/fzf-git.sh
@@ -139,16 +139,15 @@ if [[ $1 = --list ]]; then
       url=${remote_url%.git}
     fi
 
-    case "$(uname -s)" in
-      Darwin)
+    case "$(uname -sr)" in
+      Darwin*)
         open "$url$path"
         ;;
+      *microsoft* | *Microsoft*)
+        explorer.exe "$url$path"
+        ;;
       *)
-        if [[ -n "${WSL_DISTRO_NAME:-}" ]]; then
-          explorer.exe "$url$path"
-        else
-          xdg-open "$url$path"
-        fi
+        xdg-open "$url$path"
         ;;
     esac
     exit 0


### PR DESCRIPTION
When I googled for environment variables, some candidates were `$WSL_DISTRO_NAME`, `$WSLENV`, and `$WSL_INTEROP`. I decided to choose `$WSL_DISTRO_NAME`, as its name clearly conveys its purpose to me.  
I confirmed that this environment variable is defined by default in the following WSL distributions:

- Ubuntu-24.04
- Debian
- archlinux
- FedoraLinux-42
- [NixOS-WSL](https://github.com/nix-community/NixOS-WSL/releases/tag/2411.6.0)

Fixes #40