### PR TITLE
feat: Add help message for fzf-git bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Usage
 
 ### List of bindings
 
+* <kbd>CTRL-G</kbd><kbd>?</kbd> to show this list
 * <kbd>CTRL-G</kbd><kbd>CTRL-F</kbd> for **F**iles
 * <kbd>CTRL-G</kbd><kbd>CTRL-B</kbd> for **B**ranches
 * <kbd>CTRL-G</kbd><kbd>CTRL-T</kbd> for **T**ags


### PR DESCRIPTION
List the default keybindings with <kbd>CTRL-G</kbd><kbd>?</kbd>.

Differences between Bash and Zsh implementations:
- In Bash, use `bind -x` to execute a shell command when the key sequence is pressed.
- In Zsh, use `zle -M` to display a message below the command line. The message remains visible even after the widget returns, until it is replaced by another command.

Pros:
- Fix #76

Cons:
- `_fzf_git_list_bindings` must be manually kept in sync with the README

![zsh](https://github.com/user-attachments/assets/a1900de7-b033-4360-a493-e847b72fb1d4)

EDIT1: add gif
