### PR TITLE
Fix become/execute/preview if $SHELL is not bash

### DIFF
--- a/fzf-git.sh
+++ b/fzf-git.sh
@@ -167,7 +167,10 @@ else
       --border-label-pos 2 \
       --color 'label:blue' \
       --preview-window 'right,50%' --preview-border line \
-      --bind 'ctrl-/:change-preview-window(down,50%|hidden|)' "$@"
+      --bind 'ctrl-/:change-preview-window(down,50%|hidden|)' "$@" \
+      --with-shell 'bash -c' # All `become`, `execute`,
+                             # and `preview` commands in this file were written
+                             # to be executed with bash.
   }
 fi
 


### PR DESCRIPTION
In bash, for the following command:

```bash
SHELL='fish' _fzf_git_branches
```

the preview would fail with an error like:

"fish: Expected a string, but found a redirection
grep -o '[a-f0-9]\{7,\}' <<< '* 2025-07-10 79e10cc CTRL-G + ?: Add help message for fzf-git bindings (#78) (LangLangBart)' | head -n 1 | xargs git show --color=always | diff-so-fancy | less"

To prevent this, explicitly specify `--with-shell 'bash'` in `_fzf_git_fzf`.

Note that this was discovered after merging (#80).