### PR TITLE
Bind fish shell key bindings in both insert and default mode

### DIFF
--- a/fzf-git.fish
+++ b/fzf-git.fish
@@ -12,6 +12,8 @@ set --local commands branches each_ref files hashes lreflogs remotes stashes tag
 for command in $commands
     set --function key (string sub --length=1 $command)
 
-    eval "bind \cg$key   '__fzf_git_sh $command'"
-    eval "bind \cg\c$key '__fzf_git_sh $command'"
+    eval "bind -M default \cg$key   '__fzf_git_sh $command'"
+    eval "bind -M insert  \cg$key   '__fzf_git_sh $command'"
+    eval "bind -M default \cg\c$key '__fzf_git_sh $command'"
+    eval "bind -M insert  \cg\c$key '__fzf_git_sh $command'"
 end


### PR DESCRIPTION
The fish shell keybindings introduced in https://github.com/junegunn/fzf-git.sh/pull/80 are only available in the default mode. This is because the [bind](https://fishshell.com/docs/current/cmds/bind.html#:~:text=Defaults%20to%20%E2%80%9Cdefault%E2%80%9D) function by default assumes the default mode when not specified explicitly.

This means that users of the [vim keybindings](https://fishshell.com/docs/current/cmds/fish_vi_key_bindings.html) in fish have to switch to the default ("normal") mode first, before the keybindings are available. This is somewhat unexpected, as a user would assume them to also be present in insert mode, which is the mode the shell will start in.

This patch resolves this issue by binding the keybindings in both insert and default mode, similarly to what is done on the main fzf repo (see [here](https://github.com/junegunn/fzf/blob/de4059c8fa9d88247e0716f546a76d65fa3eb17b/shell/key-bindings.fish#L217-L228)).