### PR TITLE
fix(zsh): replace nonomatch with noglob in __fzf_git_init

### DIFF
--- a/fzf-git.sh
+++ b/fzf-git.sh
@@ -364,7 +364,7 @@ elif [[ -n "${ZSH_VERSION:-}" ]]; then
   }
 
   __fzf_git_init() {
-    setopt localoptions nonomatch
+    setopt localoptions no_glob
     local m o
     for o in "$@"; do
       if [[ ${o[1]} == "?" ]];then


### PR DESCRIPTION
fix #84
