### PR TITLE
fix: stash preview: use --first-parent to show changes

### DIFF
--- a/fzf-git.sh
+++ b/fzf-git.sh
@@ -264,7 +264,7 @@ _fzf_git_stashes() {
     --border-label '🥡 Stashes ' \
     --header 'CTRL-X (drop stash)' \
     --bind 'ctrl-x:reload(git stash drop -q {1}; git stash list)' \
-    -d: --preview "git show --color=$(__fzf_git_color .) {1} | $(__fzf_git_pager)" "$@" |
+    -d: --preview "git show --first-parent --color=$(__fzf_git_color .) {1} | $(__fzf_git_pager)" "$@" |
   cut -d: -f1
 }
 


### PR DESCRIPTION
ref #87

using "ref" instead of "fix" to avoid auto-closing the issue until confirmed

---

> I don't really have clear steps to reproduce this issue

```bash
# modify a file, e.g. 'fzf-git.sh'
# stage it
git add .
# save the stash
git stash save

# Press ^G+S or run '_fzf_git_stashes'
# Notice u don't see the diff in the fzf preview
```

> Can you try the diff below and check if it fixes your issue by using the `-m` flag?
>
> * Ref: [Git - git-show Documentation](https://git-scm.com/docs/git-show#Documentation/git-show.txt--m)

I think using `git show --first-parent ...` would be more what the users expects to see, as it gives the "big picture" of stashed changes (unstaged + staged vs. the base commit you were on)

The `-m` would show up to two diffs, against each parent for the given stash ref.
