### PR TITLE
fix(zsh): make __fzf_git_join quoting more robust

### DIFF
--- a/fzf-git.sh
+++ b/fzf-git.sh
@@ -358,8 +358,8 @@ if [[ -n "${BASH_VERSION:-}" ]]; then
 elif [[ -n "${ZSH_VERSION:-}" ]]; then
   __fzf_git_join() {
     local item
-    while read item; do
-      echo -n "${(q)item} "
+    while read -r item; do
+      echo -n -E "${(q)${(Q)item}} "
     done
   }
 


### PR DESCRIPTION
fix #91

@jyeharry

## to reproduce

```bash
mkdir -p path
touch "path/to my file.md"
git add .

git -c color.status=auto status --short --no-branch
# A  "path/to my file.md"

git -c color.status=auto status --short --no-branch | cut -c4- | sed 's/.* -> //' | __fzf_git_join
# \"path/to\ my\ file.md\"
```

## possible solution

- the extra `-E` for backslash escaping[^1]
- `(Q)`[^2] to remove an extra level of quotes

### demo OLD vs NEW

```bash
cat <<'EOF' | (echo "ORIGINAL:OLD:NEW"; while read -r item; do (print -rn -- "${item} :" ; echo -nE "${(q)item} :"; echo -nE "${(q)${(Q)item}} "; echo); done) | column -ts ':'
fzf-git.sh
"path/to my file.md"
"to my star*.txt"
"hello\world.bat"
"hello\world space.bat"
stash@{2}
EOF
```

```txt
ORIGINAL                  OLD                           NEW
fzf-git.sh                fzf-git.sh                    fzf-git.sh
"path/to my file.md"      \"path/to\ my\ file.md\"      path/to\ my\ file.md
"to my star*.txt"         \"to\ my\ star\*.txt\"        to\ my\ star\*.txt
"hello\world.bat"         \"hello\\world.bat\"          hello\\world.bat
"hello\world space.bat"   \"hello\\world\ space.bat\"   hello\\world\ space.bat
stash@{2}                 stash@\{2\}                   stash@\{2\}
```

[^1]: [[zsh] Fix backslash escaping · junegunn/fzf](https://github.com/junegunn/fzf/pull/3909)
[^2]: [Zsh Parameter Expansion Q](https://www.bashsupport.com/zsh/parameter-expansion-flags/q_uppercase/)
