### PR TITLE
fix: run git rev-parse without argument in _fzf_git_check

### DIFF
--- a/fzf-git.sh
+++ b/fzf-git.sh
@@ -172,7 +172,7 @@ else
 fi
 
 _fzf_git_check() {
-  git rev-parse HEAD > /dev/null 2>&1 && return
+  git rev-parse > /dev/null 2>&1 && return
 
   [[ -n $TMUX ]] && tmux display-message "Not in a git repository"
   return 1


### PR DESCRIPTION

### problem

I tried running '^G+F' on a new Git repo that has no commits yet. Nothing happended.

To reproduce, run the commands below and press '^G+F' — notice that nothing happens.

```bash
mkdir -p test_repo
cd test_repo
git init

# optionally, create some directories/ files
for i in {1..10000}; do echo dir_$i/{foo,bar,baz}; done | xargs mkdir -p
for i in {1..10000}; do echo dir_$i/{foo,bar,baz}/file.txt; done | xargs touch
```

---

### solution

Run git rev-parse with no arguments 

Related discussion:

https://lore.kernel.org/git/CAPig+cQ39Z+WjThqkxCKgOUfkZyB6PG-6RhHBYhinp-ZY4dxKA@mail.gmail.com/T/#u
