### PR TITLE
fix: ensure query set when in subdirectories

### DIFF
--- a/fzf-git.sh
+++ b/fzf-git.sh
@@ -185,7 +185,7 @@ _fzf_git_files() {
   _fzf_git_check || return
   local root query extract_file_name
   root=$(git rev-parse --show-toplevel)
-  [[ $root != "$PWD" ]] && query='!../ '
+  [[ -n "$(git rev-parse --show-prefix)" ]] && query='!../ '
 
   read -r -d "" extract_file_name <<'EOF'
 "$(cut -c4- <<< {} | sed 's/.* -> //;s/^"//;s/"$//;s/\\"/"/g')"


### PR DESCRIPTION
## Problem

On a case-insensitive filesystem, when the repo path is entered with the correct
chars but the wrong case, the filesystem can still locate it. But, `pwd` and
`git rev-parse --show-toplevel` will show different paths.

### To Reproduce

- enter a Git repo with a different case char, for example, `cd FzF-GiT.sh`.
- run `pwd`.
- run `git rev-parse --show-toplevel`.
- notice issue

## Related
- https://unix.stackexchange.com/questions/197993
- https://github.com/Yoast/plugin-development-docker/issues/28
- ... more links can be found by searching online
