### PR TITLE
fix(fish): Repaint commandline to not mess with custom prompts

### DIFF
--- a/fzf-git.fish
+++ b/fzf-git.fish
@@ -5,6 +5,7 @@ function __fzf_git_sh
     set --function fzf_git_sh_path (realpath (status dirname))
 
     commandline --insert (SHELL=bash bash "$fzf_git_sh_path/fzf-git.sh" --run $argv | string join ' ')
+    commandline -f repaint
 end
 
 set --local commands branches each_ref files hashes lreflogs remotes stashes tags worktrees


### PR DESCRIPTION
Very short fix for #105.

I just repaint the commandline after fzf-git execution.