### PR TITLE
fix(fish): echo the result when in command substitution

### DIFF
--- a/fzf-git.fish
+++ b/fzf-git.fish
@@ -4,8 +4,14 @@ function __fzf_git_sh
     # having to modify `$PATH`.
     set --function fzf_git_sh_path (realpath (status dirname))
 
-    commandline --insert (SHELL=bash bash "$fzf_git_sh_path/fzf-git.sh" --run $argv | string join ' ')
-    commandline -f repaint
+    set --function result (SHELL=bash bash "$fzf_git_sh_path/fzf-git.sh" --run $argv | string join ' ')
+
+    if status is-command-substitution && test -n "$result"
+        echo -- $result
+    else
+        commandline --insert $result
+        commandline -f repaint
+    end
 end
 
 set --local commands branches each_ref files hashes lreflogs remotes stashes tags worktrees


### PR DESCRIPTION
I set up `fzf-git.fish` for myself and wanted to use `git switch (__fzf_git_sh branches)`, but it failed. `git switch` failed with a message that it has no branch provided, the prompt repainted, and the branch name got inserted into an empty prompt.

This change seems to fix this by echoing the result when we are running in command substitution (and we got a result).