### PR TITLE
Fix ALT-F “no such file” errors in preview and empty files list for root commit

### DIFF
--- a/fzf-git.sh
+++ b/fzf-git.sh
@@ -222,11 +222,12 @@ EOF
 _fzf_git_tree_files() {
   _fzf_git_check || return
 
-  local treeish cdup
+  local treeish cdup prefix
   cdup="$(git rev-parse --show-cdup)"
+  prefix="$(git rev-parse --show-prefix)"
   for treeish in "$@"; do
     git diff-tree --root --no-commit-id --name-only --line-prefix="$cdup" "$treeish" -r
-  done | sort -u |
+  done | sort -u | sed "s|^$cdup$prefix||" |
     _fzf_git_fzf -m \
       --border-label "📂 Files in $* " \
       --header 'CTRL-O (open in browser) ╱ ALT-E (open in editor)' \

--- a/fzf-git.sh
+++ b/fzf-git.sh
@@ -222,9 +222,10 @@ EOF
 _fzf_git_tree_files() {
   _fzf_git_check || return
 
-  local treeish
+  local treeish cdup
+  cdup="$(git rev-parse --show-cdup)"
   for treeish in "$@"; do
-    git diff-tree --root --no-commit-id --name-only "$treeish" -r
+    git diff-tree --root --no-commit-id --name-only --line-prefix="$cdup" "$treeish" -r
   done | sort -u |
     _fzf_git_fzf -m \
       --border-label "📂 Files in $* " \

--- a/fzf-git.sh
+++ b/fzf-git.sh
@@ -224,7 +224,7 @@ _fzf_git_tree_files() {
 
   local treeish
   for treeish in "$@"; do
-    git diff-tree --no-commit-id --name-only "$treeish" -r
+    git diff-tree --root --no-commit-id --name-only "$treeish" -r
   done | sort -u |
     _fzf_git_fzf -m \
       --border-label "📂 Files in $* " \


### PR DESCRIPTION
When invoked in a subdirectory, `ALT-F` fails with (in the case of `bat`)

```
[bat error]: 'bashrc.d/fzf-git.sh': No such file or directory (os error 2)
```

because `_fzf_git_tree_files()` passes a path that is relative to the repo root
to a program that is invoked from a subdirectory thereof.

Launching `$EDITOR` with `ALT-E` fails for the same reason.

This change fixes the latter issue by passing an absolute path to the
editor, and the former by changing the working directory before calling
the previewer. That way, `bat` won't display the full file path in the
header, which wouldn't be helpful in the context of a Git repo.

I didn't touch the “Launch in Browser” stuff because I don't use it, so I don't
have a well-formed understanding of how it should behave.
